### PR TITLE
Display pass/fail information for all tests

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -87,6 +87,10 @@
 		window.document.addEventListener('DOMContentLoaded', function() {
 			var currentTestAssertions = [];
 
+			QUnit.begin(function() {
+				console.log("");
+			});
+
 			QUnit.log(function(details) {
 				var response;
 
@@ -112,24 +116,34 @@
 				currentTestAssertions.push('Failed assertion: ' + response);
 			});
 
+			QUnit.moduleStart(function( details ) {
+				console.log(details.name);
+			});
+
+			QUnit.moduleDone(function( details ) {
+				console.log("");
+			});
+
 			QUnit.testDone(function(result) {
 				var i,
 					len,
 					name = result.module + ': ' + result.name;
 
-				if (result.failed) {
-					console.log('Test failed: ' + name);
+				console.log((!result.failed ? "✔ ": "✖ ") + result.name);
 
+				if (result.failed) {
+					console.log("");
 					for (i = 0, len = currentTestAssertions.length; i < len; i++) {
-						console.log('    ' + currentTestAssertions[i]);
+						console.log(currentTestAssertions[i]);
 					}
+					console.log("");
 				}
 
 				currentTestAssertions.length = 0;
 			});
 
 			QUnit.done(function(result) {
-				console.log('Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+				console.log('Took ' + result.runtime +  'ms to run ' + result.total + ' assertions. ' + result.passed + ' passed, ' + result.failed + ' failed.');
 
 				if (typeof window.callPhantom === 'function') {
 					window.callPhantom({


### PR DESCRIPTION
Displaying results for all test seems more informative. I've been using this with Travis-CI, see an [example log output](https://travis-ci.org/andris9/simpleStorage/builds/19055440).

``` shell
$ phantomjs runner.js http://localhost:8888/tests/

keys
✔ can use
✔ can not use
✔ flush/index
....

Took 2796ms to run 45 assertions. 45 passed, 0 failed.
```
