### PR TITLE
It is possible to implement a solution to write a XML File for jUnit ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Show test cases:
 ```bash
 $ phantomjs path/to/runner-list.js [url-of-your-qunit-testsuite]
 ```
+## Use with jUnit and write an result.xml file
+In that case to output a xml file for the testresult's, it's possible to load the qUnit Plugin [https://github.com/JamesMGreene/qunit-reporter-junit] and write at the top of you qUnit HTML File:
+
+`
+<script>
+    if (typeof window.callPhantom === 'function') {
+        window.callPhantom({jUnitReportFile: 'test1.xml'});
+    }
+</script>
+`
+
 ## Timeout
 In `v2.0`, a default timeout of 5 seconds was added. The timeout was optional before. This could cause tests to break, which is the reason for the major version bump.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Show test cases:
 $ phantomjs path/to/runner-list.js [url-of-your-qunit-testsuite]
 ```
 ## Use with jUnit and write an result.xml file
-In that case to output a xml file for the testresult's, it's possible to load the qUnit Plugin [https://github.com/JamesMGreene/qunit-reporter-junit] and write at the top of you qUnit HTML File:
+In that case to output a xml file for the testresults, it's possible to load the QUnit Plugin [https://github.com/JamesMGreene/qunit-reporter-junit] and write at the top of you QUnit HTML File:
 
 ```html
 <script>
@@ -35,6 +35,8 @@ In that case to output a xml file for the testresult's, it's possible to load th
     }
 </script>
 ```
+
+after that, a "test1.xml" file will be written in you root directory.
 
 ## Timeout
 In `v2.0`, a default timeout of 5 seconds was added. The timeout was optional before. This could cause tests to break, which is the reason for the major version bump.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ $ phantomjs path/to/runner-list.js [url-of-your-qunit-testsuite]
 ## Use with jUnit and write an result.xml file
 In that case to output a xml file for the testresult's, it's possible to load the qUnit Plugin [https://github.com/JamesMGreene/qunit-reporter-junit] and write at the top of you qUnit HTML File:
 
-`
+```html
 <script>
     if (typeof window.callPhantom === 'function') {
         window.callPhantom({jUnitReportFile: 'test1.xml'});
     }
 </script>
-`
+```
 
 ## Timeout
 In `v2.0`, a default timeout of 5 seconds was added. The timeout was optional before. This could cause tests to break, which is the reason for the major version bump.


### PR DESCRIPTION
Hello,

i create a patch for one possible solution (maybe not the best one) to write a jUnit xml file into the filesystem. 

Background:
I use maven to run my unitTests in the CI System and i would be nice to see what unittests are run.

Thanks
Marcel
