### PR TITLE
Add additional argument to set page properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ phantomjs path/to/runner.js [url-of-your-qunit-testsuite]
 With options:
 
 ```bash
-$ phantomjs [phantom arguments] path/to/runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]
+$ phantomjs [phantom arguments] path/to/runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds] [page-properties]
 ```
 
 Show test cases:
@@ -25,6 +25,13 @@ Show test cases:
 ```bash
 $ phantomjs path/to/runner-list.js [url-of-your-qunit-testsuite]
 ```
+
+Example setting the viewport size:
+
+```bash
+$ phantomjs path/to/runner-list.js [url-of-your-qunit-testsuite] 5 '{"viewportSize":{"width":1000,"height":1000}}'
+```
+
 ## Timeout
 In `v2.0`, a default timeout of 5 seconds was added. The timeout was optional before. This could cause tests to break, which is the reason for the major version bump.
 

--- a/runner-json.js
+++ b/runner-json.js
@@ -8,7 +8,7 @@
 
     // arg[0]: scriptName, args[1...]: arguments
     if (args.length < 2) {
-        console.error('Usage:\n  phantomjs [phantom arguments] runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
+        console.error('Usage:\n  phantomjs [phantom arguments] runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds] [page-properties]');
         exit(1);
     }
 
@@ -19,6 +19,20 @@
     }
 
     page = require('webpage').create();
+
+    if (args[3] !== undefined) {
+        try {
+            var pageProperties = JSON.parse(args[3]);
+
+            if (pageProperties) {
+                for (var prop in pageProperties) {
+                    page[prop] = pageProperties[prop];
+                }
+            }
+        } catch(e) {
+            console.error('Error parsing "' + args[3] + '": ' + e);
+        }
+    }
 
     // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
     page.onConsoleMessage = function (msg) {

--- a/runner-list.js
+++ b/runner-list.js
@@ -8,7 +8,7 @@
 
     // arg[0]: scriptName, args[1...]: arguments
     if (args.length < 2) {
-        console.error('Usage:\n  phantomjs [phantom arguments] runner-list.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
+        console.error('Usage:\n  phantomjs [phantom arguments] runner-list.js [url-of-your-qunit-testsuite] [timeout-in-seconds] [page-properties]');
         exit(1);
     }
 
@@ -19,6 +19,20 @@
     }
 
     page = require('webpage').create();
+
+    if (args[3] !== undefined) {
+        try {
+            var pageProperties = JSON.parse(args[3]);
+
+            if (pageProperties) {
+                for (var prop in pageProperties) {
+                    page[prop] = pageProperties[prop];
+                }
+            }
+        } catch(e) {
+            console.error('Error parsing "' + args[3] + '": ' + e);
+        }
+    }
 
     // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
     page.onConsoleMessage = function (msg) {

--- a/runner.js
+++ b/runner.js
@@ -8,7 +8,7 @@
 
     // arg[0]: scriptName, args[1...]: arguments
     if (args.length < 2) {
-        console.error('Usage:\n  phantomjs [phantom arguments] runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
+        console.error('Usage:\n  phantomjs [phantom arguments] runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds] [page-properties]');
         exit(1);
     }
 
@@ -19,6 +19,20 @@
     }
 
     page = require('webpage').create();
+
+    if (args[3] !== undefined) {
+        try {
+            var pageProperties = JSON.parse(args[3]);
+
+            if (pageProperties) {
+                for (var prop in pageProperties) {
+                    page[prop] = pageProperties[prop];
+                }
+            }
+        } catch(e) {
+            console.error('Error parsing "' + args[3] + '": ' + e);
+        }
+    }
 
     // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
     page.onConsoleMessage = function (msg) {

--- a/test/fixtures/custom-viewport.html
+++ b/test/fixtures/custom-viewport.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>QUnit Test Suite</title>
+    <link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css" type="text/css" media="screen">
+    <script type="text/javascript" src="../../node_modules/qunitjs/qunit/qunit.js"></script>
+    <!-- Your project file goes here -->
+    <!-- <script type="text/javascript" src="myProject.js"></script>   -->
+    <!-- Your tests file goes here -->
+    <!-- <script type="text/javascript" src="myTests.js"></script>   -->
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+
+    <script>
+      test('viewport', function() {
+        ok(window.innerWidth === 1000, 'Window is 1000px wide');
+      });
+    </script>
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -32,6 +32,11 @@ var assert = require('assert'),
             childArgs.unshift( args[3] );
         }
 
+        // Optional page properties value
+        if ( args[4] ) {
+            childArgs.push( args[4] );
+        }
+
         childProcess.execFile(binPath, childArgs, function (err, stdout, stderr) {
             if (stdout) {
                 stdout = stdout.trim(); // Trim trailing cr-lf
@@ -46,7 +51,13 @@ var assert = require('assert'),
                 console.log(err);
             }*/
         });
-    };
+    },
+    pageProperties = JSON.stringify({
+        viewportSize: {
+            width: 1000,
+            height: 1000
+        }
+    });
 
 describe('qunit-phantomjs-runner runner.js', function () {
     this.timeout(5000);
@@ -159,6 +170,19 @@ describe('qunit-phantomjs-runner runner.js', function () {
             }
         };
     });
+
+    it('should set custom viewport', function (cb) {
+
+        qunit('test/fixtures/custom-viewport.html', '../runner.js', 5, '', pageProperties);
+
+        process.stdout.write = function (str) {
+            //out(str);
+
+            assert.ok(/1 passed. 0 failed./.test(str));
+            process.stdout.write = out;
+            cb();
+        };
+    });
 });
 
 describe('qunit-phantomjs-runner runner-list.js', function () {
@@ -242,6 +266,19 @@ describe('qunit-phantomjs-runner runner-list.js', function () {
             cb();
         };
     });
+
+    it('should set custom viewport', function (cb) {
+
+        qunit('test/fixtures/custom-viewport.html', '../runner-list.js', 5, '', pageProperties);
+
+        process.stdout.write = function (str) {
+            //out(str);
+
+            assert.ok(/1 passed. 0 failed./.test(str));
+            process.stdout.write = out;
+            cb();
+        };
+    });
 });
 
 describe('qunit-phantomjs-runner runner-json.js', function () {
@@ -321,6 +358,19 @@ describe('qunit-phantomjs-runner runner-json.js', function () {
             //out(str);
 
             assert.ok(/Unable to access network:/.test(str));
+            process.stdout.write = out;
+            cb();
+        };
+    });
+
+    it('should set custom viewport', function (cb) {
+
+        qunit('test/fixtures/custom-viewport.html', '../runner-json.js', 5, '', pageProperties);
+
+        process.stdout.write = function (str) {
+            //out(str);
+
+            assert.ok(/"failed":0,"passed":1,"total":1/.test(str));
             process.stdout.write = out;
             cb();
         };


### PR DESCRIPTION
As explained in https://github.com/jonkemp/gulp-qunit/issues/24, it would be very helpful to be able to set page properties like `viewportSize`.

The solution proposed here is certainly not very elegant (`timeout` option has to be present, value needs to be a JSON string) but it lead to minimal changes to the existing code.

What do you think?